### PR TITLE
Dockerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:16-alpine
+
+WORKDIR /app
+
+RUN chown 1000:1000 /app
+
+USER 1000:1000
+
+COPY package*.json ./
+
+RUN npm ci --production
+
+COPY . .
+
+VOLUME /app/config
+VOLUME /app/downloads
+
+ENV CONFIG_PATH=/app/config/config.json
+CMD ["node", "app.js"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Copy `config.example.json` to `config.json` and change credentials and courses i
 
 Run the app with: `npm start`
 
+## [Optional] Quick Start with Docker
+
+If you have docker you can execute the `docker.sh` to build and use the downloader inside of a container.
+
+Note that it only works if your user and groups have 1000 as UID and GID.
+
 ## Config
 
 > The config file has 3 sections.

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if ! docker image inspect unifi-webex-dl:latest &>/dev/null; then
+    docker build -t unifi-webex-dl .
+fi
+
+if [ ! -f "./config.json" ]; then
+    echo "Missing './config.json' file";
+    exit 1
+fi
+
+if [ ! -d "./downloads" ]; then
+    echo "Missing './downloads' folder, creating it";
+    mkdir ./downloads
+fi
+
+docker run --rm --init -it \
+    -v "$PWD/config.json":/app/config/config.json \
+    -v "$PWD/downloads":/app/downloads \
+    unifi-webex-dl

--- a/helpers/download.js
+++ b/helpers/download.js
@@ -23,10 +23,10 @@ function mkdirIfNotExists(dir_path) {
                         reject(`Error creating directory. ${err.code}`);
                     resolve();
                 });
+            } else {
+                // dir exists
+                resolve();
             }
-
-            // dir exists
-            resolve();
         });
     });
 }


### PR DESCRIPTION
The image defaults to the canonical JSON config file, and moving files out of the tmp folder [isn't directly possible](https://docs.docker.com/storage/storagedriver/overlayfs-driver/#modifying-files-or-directories). The workaround doesn't seem to have a significant impact on performance on modern HW.

Also fixed [a small and rare](https://github.com/beryxz/unifi-webex-dl/compare/beryxz:c16a7b6...nmaggioni:65ec506#diff-15958a12f474f4a28a9af0839b77162d86eff4d108fd868a32eba115635737c5R26) race condition.