### PR TITLE
Added the option to numerate lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Please note that on Windows the `name` field shouldn't contain any of the not al
 | `skip_before_date` | string     | Yes      | Skip recordings before the date `YYYY-MM-DD`.                                                                       |
 | `skip_after_date`  | string     | Yes      | Skip recordings after the date `YYYY-MM-DD`.                                                                        |
 | `prepend_date`     | boolean    | Yes      | Prepend the date of the recording (`YYYYMMDD-`) to the filenames.                                                   |
-| `putNumberLesson`  | boolean     | Yes      | Appends the lessons a number (from 1 to the number of lesson available) at the start of the file name of the lesson.                                                                        |
+| `prepend_number`  | boolean     | Yes      | Appends the lessons a number (from 1 to the number of lesson available) at the start of the file name of the lesson.                                                                        |
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Please note that on Windows the `name` field shouldn't contain any of the not al
 | `skip_before_date` | string     | Yes      | Skip recordings before the date `YYYY-MM-DD`.                                                                       |
 | `skip_after_date`  | string     | Yes      | Skip recordings after the date `YYYY-MM-DD`.                                                                        |
 | `prepend_date`     | boolean    | Yes      | Prepend the date of the recording (`YYYYMMDD-`) to the filenames.                                                   |
+| `putNumberLesson`  | boolean     | Yes      | Appends the lessons a number (from 1 to the number of lesson available) at the start of the file name of the lesson.                                                                        |
 
 ## Environment variables
 

--- a/app.js
+++ b/app.js
@@ -167,7 +167,7 @@ async function processCourseRecordings(course, recordings, downloadConfigs, nLes
                 let filename = replaceWhitespaceChars(replaceWindowsSpecialChars(`${recording.name}.${recording.format}`, '_'), '_');
                 if (course.prepend_date)
                     filename = `${getUTCDateTimestamp(recording.created_at, '')}-${filename}`;
-                if (course.putNumberLesson) {
+                if (course.prepend_number) {
                     filename = `${lesson_number.toString()}-${filename}`;
                     logger.debug(filename);
                     lesson_number --;

--- a/app.js
+++ b/app.js
@@ -157,8 +157,6 @@ async function processCourseRecordings(course, recordings, downloadConfigs, nLes
 
     const chunks = splitArrayInChunksOfFixedLength(recordings, downloadConfigs.max_concurrent_downloads);
 
-    let lesson_number = nLessons; //let it start from 1
-
     for (const chunk of chunks) {
         const multiProgressBar = (downloadConfigs.progress_bar ? new MultiProgressBar(false) : null);
 
@@ -168,9 +166,9 @@ async function processCourseRecordings(course, recordings, downloadConfigs, nLes
                 if (course.prepend_date)
                     filename = `${getUTCDateTimestamp(recording.created_at, '')}-${filename}`;
                 if (course.prepend_number) {
-                    filename = `${lesson_number.toString()}-${filename}`;
+                    filename = `${nLessons.toString()}-${filename}`;
                     logger.debug(filename);
-                    lesson_number --;
+                    nLessons --;
                 }
 
                 await downloadRecording(recording, filename, courseDownloadPath, downloadConfigs, multiProgressBar);

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -14,6 +14,7 @@ const { execSync } = require('child_process');
  * @property {string} skip_before_date
  * @property {string} skip_after_date
  * @property {boolean} prepend_date
+ * @property {boolean} putNumberLesson
  */
 
 /**

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -14,7 +14,7 @@ const { execSync } = require('child_process');
  * @property {string} skip_before_date
  * @property {string} skip_after_date
  * @property {boolean} prepend_date
- * @property {boolean} putNumberLesson
+ * @property {boolean} prepend_number
  */
 
 /**


### PR DESCRIPTION
I added the option to number the lessons in the order they were uploaded on webex.
It's similar to the `prepend_date` but it uses the total number of lessons uploaded (from `recordings.totalCount`) instead of the date and time.
It uses a variable tat you can place in the courses section (`putNumberLesson`).